### PR TITLE
Add a `nix flake`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
    ```
 *Note: If running the executable does not work, you will have to build the project from source.* 
 
+### NixOS:
+If you're on NixOS or have Nix installed with Flakes enabled, you can instead use
+```sh
+nix run github:UnlegitSenpaii/FAE_Linux /path/to/Factorio/bin/x64/factorio
+```
+
 ## Building from Source
 Follow these steps to build the binary yourself:
 1. Clone the repository:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753345091,
+        "narHash": "sha256-CdX2Rtvp5I8HGu9swBmYuq+ILwRxpXdJwlpg8jvN4tU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3ff0e34b1383648053bba8ed03f201d3466f90c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "FAE_Linux - Flake with build and dev shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      # Required build tools
+      deps = with pkgs; [
+        cmake
+        gcc
+      ];
+    in
+    {
+      packages.default = pkgs.stdenv.mkDerivation {
+        pname = "FAE_Linux";
+        version = "0.1";
+
+        src = ./.;
+
+        nativeBuildInputs = with pkgs; [ cmake gcc ];
+
+        buildInputs = deps;
+
+        buildPhase = ''
+          cmake .
+          make -j8
+        '';
+        
+        installPhase = ''
+          mkdir -p $out/bin/
+          cp ./out/bin/FAE_Linux $out/bin/FAE_Linux
+        '';
+      };
+
+      devShells.default = pkgs.mkShell {
+        buildInputs = deps;
+        shellHook = ''
+          echo "You're now in the FAE_Linux dev shell."
+          echo "To build manually:"
+          echo "  cmake . && make"
+        '';
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,15 +8,9 @@
 
   outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem (system:
     let
-      pkgs = import nixpkgs {
-        inherit system;
-      };
+      pkgs = nixpkgs.legacyPackages.${system};
 
       # Required build tools
-      deps = with pkgs; [
-        cmake
-        gcc
-      ];
     in
     {
       packages.default = pkgs.stdenv.mkDerivation {
@@ -27,7 +21,6 @@
 
         nativeBuildInputs = with pkgs; [ cmake gcc ];
 
-        buildInputs = deps;
 
         buildPhase = ''
           cmake .
@@ -41,7 +34,7 @@
       };
 
       devShells.default = pkgs.mkShell {
-        buildInputs = deps;
+        inputsFrom = [ self.packages.${pkgs.system}.default ];
         shellHook = ''
           echo "You're now in the FAE_Linux dev shell."
           echo "To build manually:"


### PR DESCRIPTION
This change at it's core makes it so that users with `nix` installed can run the application without needing to do any extra steps. It ensures all dependencies (not that there are many) are met and with sufficient versions.

I tested it by doing
`nix run github:krutonium/FAE_Linux /games/SteamLibrary/steamapps/common/Factorio/bin/x64/factorio`

where it then proceeded to compile and run, then successfully patched Factorio. 