### PR TITLE
Fix Factorio failing to launch via Steam: `file` LD_PRELOAD crash + missing `chmod +x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Your Factorio folder is usually at:
 ```
 Copy `fae.sh` and the `FAE_Linux` binary directly into that folder (not into `bin/` or any subfolder).
 
+Then make the `FAE_Linux` binary executable:
+```sh
+chmod +x ~/.local/share/Steam/steamapps/common/Factorio/FAE_Linux
+```
+
 **Step 2 — Set it as a Steam launch option**
 
 In Steam: right-click **Factorio** → **Properties** → **Launch Options**, and the full path of the dropped `fae.sh` script as an argument:

--- a/scripts/fae.sh
+++ b/scripts/fae.sh
@@ -135,7 +135,7 @@ download_latest_release() {
     if command -v file &>/dev/null; then
         local arch file_out arch_ok
         arch="$(uname -m)"
-        file_out="$(file "$dest_tmp" 2>/dev/null)"
+        file_out="$(run_clean file "$dest_tmp" 2>/dev/null)"
         arch_ok=true
         case "$arch" in
             x86_64)  printf '%s' "$file_out" | grep -qE 'x86-64|x86_64'      || arch_ok=false ;;
@@ -172,7 +172,7 @@ fi
 get_build_id() {
     local binary="$1"
     if command -v file &>/dev/null; then
-        file "$binary" 2>/dev/null \
+        run_clean file "$binary" 2>/dev/null \
             | sed -n 's/.*BuildID\[sha1\]=\([0-9a-f]*\).*/\1/p'
     elif command -v readelf &>/dev/null; then
         readelf -n "$binary" 2>/dev/null \

--- a/scripts/fae.sh
+++ b/scripts/fae.sh
@@ -175,7 +175,7 @@ get_build_id() {
         run_clean file "$binary" 2>/dev/null \
             | sed -n 's/.*BuildID\[sha1\]=\([0-9a-f]*\).*/\1/p'
     elif command -v readelf &>/dev/null; then
-        readelf -n "$binary" 2>/dev/null \
+        run_clean readelf -n "$binary" 2>/dev/null \
             | sed -n 's/.*Build ID: \([0-9a-f]*\).*/\1/p' | head -1
     fi
 }


### PR DESCRIPTION
Two small fixes to the automatic `fae.sh` setup, both of which stop Factorio from launching. Symptoms: `/usr/bin/file` dumps core (SIGSYS / signal 31) during the BuildID check, and the patcher fails with exit 126 (`Permission denied`) - after which the script deletes the copied binary and Factorio doesn't launch.

* **`scripts/fae.sh`** - strip Steam's `LD_PRELOAD` for `file`

  Steam injects `gameoverlayrenderer.so` via `LD_PRELOAD` into child processes. Loaded into `/usr/bin/file` (a non-game binary) it crashes during exit cleanup - SIGSYS under the Steam Linux Runtime's seccomp filter - so the BuildID and architecture checks break.

  The script already has a `run_clean` helper (used for `git`/`cmake`/`curl`/`wget`); the two `file` calls just weren't wrapped. This wraps them. Not distro-specific - affects any Steam launch with the overlay enabled.

* **`README.md`** - document `chmod +x` in Automatic Setup

  Release binaries download without the execute bit, and the script only `chmod`s binaries it downloads/builds itself, not manually-copied ones. So following the automatic instructions verbatim leaves `FAE_Linux` non-executable → exit-126 patch failure → Factorio doesn't launch. Manual Setup already documents `chmod +x`; this brings Automatic Setup in line.

**Testing**

Verified on Arch KDE Wayland + Steam (native Factorio, Steam Linux Runtime sniper): before, `file` dumped core and the game wouldn't launch; after both fixes, the patcher applies all patterns and the game launches normally.
